### PR TITLE
add prop-types dependecy to fix deprecated React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-accordion",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React accordion component which is 100% responsive.",
   "keywords": [
     "react-component",
@@ -38,7 +38,8 @@
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0",
-    "react-collapsible": "^1.3.0"
+    "react-collapsible": "^1.3.0",
+    "prop-types": "^15.5.10"
   },
   "repository": {
     "type": "git",
@@ -48,7 +49,8 @@
     "url": "https://github.com/glennflanagan/react-responsive-accordion/issues"
   },
   "scripts": {
-    "build": "babel src/Accordion.js > dist/Accordion.js",
-    "prepublish": "npm run build"
+    "build": "babel ./src/Accordion.js > ./dist/Accordion.js",
+    "prepublish": "npm run distfolder && npm run build",
+    "distfolder": "mkdir dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "scripts": {
     "build": "babel ./src/Accordion.js > ./dist/Accordion.js",
-    "prepublish": "npm run distfolder && npm run build",
-    "distfolder": "mkdir dist"
+    "prepublish": "npm run build"
   }
 }

--- a/src/Accordion.js
+++ b/src/Accordion.js
@@ -1,25 +1,26 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Collapsible from 'react-collapsible';
 
 var Accordion = React.createClass({
 
   //Set validation for prop types
   propTypes: {
-    transitionTime: React.PropTypes.number,
-    easing: React.PropTypes.string,
-    startPosition: React.PropTypes.number,
-    classParentString: React.PropTypes.string,
-    children: React.PropTypes.arrayOf(React.PropTypes.shape({
-      props: React.PropTypes.shape({
-        'data-trigger': React.PropTypes.oneOfType([
-          React.PropTypes.string,
-          React.PropTypes.element
+    transitionTime: PropTypes.number,
+    easing: PropTypes.string,
+    startPosition: PropTypes.number,
+    classParentString: PropTypes.string,
+    children: PropTypes.arrayOf(PropTypes.shape({
+      props: PropTypes.shape({
+        'data-trigger': PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.element
         ]).isRequired,
-        'data-triggerWhenOpen': React.PropTypes.oneOfType([
-          React.PropTypes.string,
-          React.PropTypes.element
+        'data-triggerWhenOpen': PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.element
         ]),        
-        'data-triggerDisabled': React.PropTypes.bool,
+        'data-triggerDisabled': PropTypes.bool,
       })
     }))
   },


### PR DESCRIPTION
- add prop-types to peerDependencies;
- use PropTypes from new module;
- update examples;
- bump version;
- ~prepublish script create folder 'dist' if not exist;~ (not work on windows)