### PR TITLE
add create-react-class to fix deprecated React.createClass warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "watchify": "^3.7.0"
   },
   "peerDependencies": {
+    "create-react-class": "^15.6.2",
     "react": "^0.14.0 || ^15.0.0-0",
     "react-collapsible": "^1.3.0",
     "prop-types": "^15.5.10"

--- a/src/Accordion.js
+++ b/src/Accordion.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Collapsible from 'react-collapsible';
+import createReactClass from 'create-react-class';
 
-var Accordion = React.createClass({
+var Accordion = createReactClass({
 
   //Set validation for prop types
   propTypes: {


### PR DESCRIPTION
issue: https://github.com/glennflanagan/react-responsive-accordion/issues/12
with this PR will eliminate that annoying warning